### PR TITLE
fix logic filtering hidden files

### DIFF
--- a/library/src/main/java/com/psaravan/filebrowserview/lib/FileBrowserEngine/FileBrowserEngine.java
+++ b/library/src/main/java/com/psaravan/filebrowserview/lib/FileBrowserEngine/FileBrowserEngine.java
@@ -86,7 +86,7 @@ public class FileBrowserEngine {
             for(int i=0; i < files.length; i++) {
 
                 File file = files[i];
-                if (file.isHidden()!=mFileBrowserView.shouldShowHiddenFiles() && file.canRead()) {
+                if ((!file.isHidden() || mFileBrowserView.shouldShowHiddenFiles()) && file.canRead()) {
 
                     if (file.isDirectory()) {
 


### PR DESCRIPTION
Hi, original logic seemed wrong, and was limiting the list of files I could see. This fix shows all the files on my sdcard for me.
